### PR TITLE
Firefox 45

### DIFF
--- a/config/archives/security.list.chroot
+++ b/config/archives/security.list.chroot
@@ -1,0 +1,1 @@
+deb http://security.debian.org/ jessie/updates main

--- a/config/includes.chroot/etc/skel/Desktop/firefox-esr.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/firefox-esr.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Link
+Name=Web Browser
+Icon=firefox-esr

--- a/config/includes.chroot/etc/skel/Desktop/firefox-esr.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/firefox-esr.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Type=Link
-Name=Web Browser
+Name=Firefox
 Icon=firefox-esr
 URL=/usr/share/applications/firefox-esr.desktop
+Name[en_GB]=Web Browser

--- a/config/includes.chroot/etc/skel/Desktop/firefox-esr.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/firefox-esr.desktop
@@ -2,3 +2,4 @@
 Type=Link
 Name=Web Browser
 Icon=firefox-esr
+URL=/usr/share/applications/firefox-esr.desktop

--- a/config/includes.chroot/etc/skel/Desktop/iceweasel.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/iceweasel.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Type=Link
-Name=Iceweasel
-Icon=iceweasel
-URL=/usr/share/applications/iceweasel.desktop
-Name[en_GB]=Web Browser

--- a/config/package-lists/w2c3.list.chroot
+++ b/config/package-lists/w2c3.list.chroot
@@ -1,6 +1,6 @@
 task-laptop
 task-lxde-desktop
-iceweasel
+firefox-esr
 
 ruby2.1
 ruby2.1-doc


### PR DESCRIPTION
Iceweasel is dead; long live Firefox.

We can get up-to-date Firefox packages from the security updates repos. This will provide ESR versions, which should be enough for our purposes.

Fixes #3
