### PR TITLE
Workaround for Flash installer bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ config/common
 config/source
 
 config/build
+config/includes.chroot/tmp
 
 source/
 source*.iso

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,18 @@
-default:
+FLASH_PLUGIN=config/includes.chroot/tmp/libflashplayer.so
+
+.PHONY: default
+
+default: live-image-amd64.hybrid.iso
+	
+live-image-amd64.hybrid.iso: $(FLASH_PLUGIN)
 	lb clean && lb config && lb build
+
+$(FLASH_PLUGIN):
+	@echo "=========================================="
+	@echo
+	@echo "  Please download the Linux flash plugin (libflashplayer.so) and leave it at:"
+	@echo
+	@echo "  $(FLASH_PLUGIN)"
+	@echo
+	@echo "=========================================="
+	@exit 1

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ First install live-build and git:
 # apt-get install live-build git
 ```
 
+---
+**NOTE**: due a current bug in Debian's Flash plugin package, there's an intermediate step to perform at this stage, at least for the time being:
+
+1. Go to Adobe Flash's website (https://get.adobe.com/flashplayer).
+2. Download the Linux 64bit version.
+3. Extract the file `libflashplayer.so`.
+4. Put this file in the folder `config/includes.chroot/tmp` in this project.
+
+Now you should be able to proceed as normal.
+
+For more information, you can find a description of the bug at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851066 
+
+---
+
 Next, clone this repository:
 
 ```

--- a/config/archives/security.list.chroot
+++ b/config/archives/security.list.chroot
@@ -1,1 +1,0 @@
-deb http://security.debian.org/ jessie/updates main

--- a/config/hooks/1000-install-flash-plugin.hook.chroot
+++ b/config/hooks/1000-install-flash-plugin.hook.chroot
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+PLUGIN_SOURCE_PATH="/live-build/config/includes.chroot/tmp/libflashplayer.so"
+PLUGIN_DIR="/usr/lib/flashplugin-nonfree"
+PLUGIN_PATH="$PLUGIN_DIR/$(basename "$PLUGIN_SOURCE_PATH")"
+
+mv "$PLUGIN_SOURCE_PATH" "$PLUGIN_PATH"
+chmod 644 "$PLUGIN_PATH"
+chown root:root "$PLUGIN_PATH"
+update-alternatives --quiet --install \
+	/usr/lib/mozilla/plugins/flash-mozilla.so \
+	flash-mozilla.so \
+	"$PLUGIN_PATH" \
+	50


### PR DESCRIPTION
Due to a bug in the relevant Debian package, the Flash plugin doesn't work in the default install. For more information, check out https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851066

This implements a workaround, as described in [comment #30](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851066#30) of the bug by James Wagner.