### PR TITLE
Thonny

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
+ARCH=x86_64
 FLASH_PLUGIN=config/includes.chroot/tmp/libflashplayer.so
+THONNY_URL=https://bitbucket.org/plas/thonny/downloads/thonny-2.1.17-$(ARCHITECTURE).tar.gz
+THONNY_PACKAGE=config/includes.chroot/tmp/thonny-installer
 
 .PHONY: default
 
 default: live-image-amd64.hybrid.iso
 	
-live-image-amd64.hybrid.iso: $(FLASH_PLUGIN)
+live-image-amd64.hybrid.iso: $(FLASH_PLUGIN) $(THONNY_PACKAGE)
 	lb clean && lb config && lb build
 
 $(FLASH_PLUGIN):
@@ -16,3 +19,6 @@ $(FLASH_PLUGIN):
 	@echo
 	@echo "=========================================="
 	@exit 1
+
+$(THONNY_PACKAGE):
+	curl -sS $(THONNY_URL) > $(THONNY_PACKAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARCH=x86_64
 FILES_CACHE_DIR=config/includes.chroot/tmp
-DOWNLOADS_CACHE_DIR=$(FILES_CACHE_DIR)/Downloads
+DOWNLOADS_CACHE_DIR=$(FILES_CACHE_DIR)/downloads
 FLASH_PLUGIN=$(FILES_CACHE_DIR)/libflashplayer.so
 THONNY_PACKAGE=thonny-2.1.17-$(ARCH).tar.gz
 THONNY_URL=https://bitbucket.org/plas/thonny/downloads/$(THONNY_PACKAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 ARCH=x86_64
-FLASH_PLUGIN=config/includes.chroot/tmp/libflashplayer.so
-THONNY_URL=https://bitbucket.org/plas/thonny/downloads/thonny-2.1.17-$(ARCHITECTURE).tar.gz
-THONNY_PACKAGE=config/includes.chroot/tmp/thonny-installer
+FILES_CACHE_DIR=config/includes.chroot/tmp
+DOWNLOADS_CACHE_DIR=$(FILES_CACHE_DIR)/Downloads
+FLASH_PLUGIN=$(FILES_CACHE_DIR)/libflashplayer.so
+THONNY_PACKAGE=thonny-2.1.17-$(ARCH).tar.gz
+THONNY_URL=https://bitbucket.org/plas/thonny/downloads/$(THONNY_PACKAGE)
+THONNY_DOWNLOAD_PATH=$(DOWNLOADS_CACHE_DIR)/$(THONNY_PACKAGE)
 
 .PHONY: default
 
 default: live-image-amd64.hybrid.iso
 	
-live-image-amd64.hybrid.iso: $(FLASH_PLUGIN) $(THONNY_PACKAGE)
+live-image-amd64.hybrid.iso: $(FLASH_PLUGIN) $(THONNY_DOWNLOAD_PATH)
 	lb clean && lb config && lb build
 
 $(FLASH_PLUGIN):
@@ -20,5 +23,6 @@ $(FLASH_PLUGIN):
 	@echo "=========================================="
 	@exit 1
 
-$(THONNY_PACKAGE):
-	curl -sS $(THONNY_URL) > $(THONNY_PACKAGE)
+$(THONNY_DOWNLOAD_PATH):
+	mkdir -p $(DOWNLOADS_CACHE_DIR)
+	wget -O $(THONNY_DOWNLOAD_PATH) $(THONNY_URL)

--- a/config/hooks/1000-install-flash-plugin.hook.chroot
+++ b/config/hooks/1000-install-flash-plugin.hook.chroot
@@ -4,7 +4,7 @@ PLUGIN_SOURCE_PATH="/live-build/config/includes.chroot/tmp/libflashplayer.so"
 PLUGIN_DIR="/usr/lib/flashplugin-nonfree"
 PLUGIN_PATH="$PLUGIN_DIR/$(basename "$PLUGIN_SOURCE_PATH")"
 
-mv "$PLUGIN_SOURCE_PATH" "$PLUGIN_PATH"
+cp "$PLUGIN_SOURCE_PATH" "$PLUGIN_PATH"
 chmod 644 "$PLUGIN_PATH"
 chown root:root "$PLUGIN_PATH"
 update-alternatives --quiet --install \

--- a/config/hooks/1010-copy-downloads.hook.chroot
+++ b/config/hooks/1010-copy-downloads.hook.chroot
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e
+
+DOWNLOADS_CACHE_DIR="/live-build/config/includes.chroot/tmp/Downloads"
+DEST_DIR="/etc/skel/Downloads"
+
+mkdir -p "$DEST_DIR"
+cp -pr "$DOWNLOADS_CACHE_DIR"/* "$DEST_DIR/"

--- a/config/hooks/1010-copy-downloads.hook.chroot
+++ b/config/hooks/1010-copy-downloads.hook.chroot
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 set -e
 
-DOWNLOADS_CACHE_DIR="/live-build/config/includes.chroot/tmp/Downloads"
-DEST_DIR="/etc/skel/Downloads"
+DOWNLOADS_CACHE_DIR="/live-build/config/includes.chroot/tmp/downloads"
+DEST_DIR="/usr/share/w2c3/software"
 
 mkdir -p "$DEST_DIR"
 cp -pr "$DOWNLOADS_CACHE_DIR"/* "$DEST_DIR/"

--- a/config/hooks/1010-install-thonny.hook.chroot
+++ b/config/hooks/1010-install-thonny.hook.chroot
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+INSTALLER_PATH="/live-build/config/includes.chroot/tmp/thonny-installer"
+
+cp $(INSTALLER_PATH) /etc/skel/home/Documents/

--- a/config/hooks/1010-install-thonny.hook.chroot
+++ b/config/hooks/1010-install-thonny.hook.chroot
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-INSTALLER_PATH="/live-build/config/includes.chroot/tmp/thonny-installer"
-
-cp $(INSTALLER_PATH) /etc/skel/home/Documents/

--- a/config/includes.chroot/etc/skel/.thonny/configuration.ini
+++ b/config/includes.chroot/etc/skel/.thonny/configuration.ini
@@ -1,0 +1,2 @@
+[view]
+show_line_numbers = True

--- a/config/includes.chroot/etc/skel/Desktop/software.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/software.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Link
+Name=Software
+Icon=folder
+URL=/usr/share/w2c3/software


### PR DESCRIPTION
Include a pre-downloaded Thonny package for installation where useful.

Thonny's installer doesn't provide an interface that we can use to properly install it during the creation of the Live CD image. We could contribute to Thonny to implement this, but for now let's be Lean and try a low-tech approach first.