### PR TITLE
Sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ Initially I thought this would be a problem, and set out to fix it. I put togeth
 However, this is not a problem anymore as at present we include all the packages we need. We want to avoid using the Internet during installation, because we normally run our coding club on places where WiFi is spotty at best.
 
 At some point I'll remove the changes I made to make this work.
+
+### Root access
+
+For root access, use `sudo`. The password is just `password`. On older installs, use `su` with the same password. Feel free to tinker with this. The worst that can happen is that the machine has to be reinstalled again, so no problem.

--- a/config/includes.binary/install/preseed.cfg
+++ b/config/includes.binary/install/preseed.cfg
@@ -9,8 +9,9 @@ d-i netcfg/enable boolean false
 d-i netcfg/get_hostname string w2c3
 d-i netcfg/get_domain string
 
-d-i passwd/root-password password
-d-i passwd/root-password-again password
+d-i passwd/root-login boolean false
+#d-i passwd/root-password password
+#d-i passwd/root-password-again password
 d-i passwd/user-fullname string Wizzie Wizzie Computer Coding Club
 d-i passwd/username string w2c3
 d-i passwd/user-password password password


### PR DESCRIPTION
While preparing the move to Stretch (Debian 9), I noticed that the preseeded root password doesn't work in that version. So I'm switching to `sudo`, which I like better anyway.