### PR TITLE
Flash, revisited

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 ARCH=x86_64
 FILES_CACHE_DIR=config/includes.chroot/tmp
 DOWNLOADS_CACHE_DIR=$(FILES_CACHE_DIR)/downloads
-FLASH_PLUGIN=$(FILES_CACHE_DIR)/libflashplayer.so
+FLASH_PLUGIN_FILE=flash_player_npapi_linux.x86_64.tar.gz
+FLASH_PLUGIN_PATH=$(FILES_CACHE_DIR)/$(FLASH_PLUGIN_FILE)
 THONNY_PACKAGE=thonny-2.1.17-$(ARCH).tar.gz
 THONNY_URL=https://bitbucket.org/plas/thonny/downloads/$(THONNY_PACKAGE)
 THONNY_DOWNLOAD_PATH=$(DOWNLOADS_CACHE_DIR)/$(THONNY_PACKAGE)
@@ -10,15 +11,15 @@ THONNY_DOWNLOAD_PATH=$(DOWNLOADS_CACHE_DIR)/$(THONNY_PACKAGE)
 
 default: live-image-amd64.hybrid.iso
 	
-live-image-amd64.hybrid.iso: $(FLASH_PLUGIN) $(THONNY_DOWNLOAD_PATH)
+live-image-amd64.hybrid.iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH)
 	lb clean && lb config && lb build
 
-$(FLASH_PLUGIN):
+$(FLASH_PLUGIN_PATH):
 	@echo "=========================================="
 	@echo
-	@echo "  Please download the Linux flash plugin (libflashplayer.so) and leave it at:"
+	@echo "  Please download the Linux flash plugin package ($(FLASH_PLUGIN_FILE)) and leave it at:"
 	@echo
-	@echo "  $(FLASH_PLUGIN)"
+	@echo "  $(FLASH_PLUGIN_PATH)"
 	@echo
 	@echo "=========================================="
 	@exit 1

--- a/config/hooks/1000-install-flash-plugin.hook.chroot
+++ b/config/hooks/1000-install-flash-plugin.hook.chroot
@@ -1,14 +1,10 @@
 #!/usr/bin/env sh
 
-PLUGIN_SOURCE_PATH="/live-build/config/includes.chroot/tmp/libflashplayer.so"
-PLUGIN_DIR="/usr/lib/flashplugin-nonfree"
-PLUGIN_PATH="$PLUGIN_DIR/$(basename "$PLUGIN_SOURCE_PATH")"
+GOODIES_DIR_PATH="/live-build/config/includes.chroot/tmp"
+PACKAGE_FILE="flash_player_npapi_linux.x86_64.tar.gz"
+PACKAGE_PATH="$GOODIES_DIR_PATH/$PACKAGE_FILE"
 
-cp "$PLUGIN_SOURCE_PATH" "$PLUGIN_PATH"
-chmod 644 "$PLUGIN_PATH"
-chown root:root "$PLUGIN_PATH"
-update-alternatives --quiet --install \
-	/usr/lib/mozilla/plugins/flash-mozilla.so \
-	flash-mozilla.so \
-	"$PLUGIN_PATH" \
-	50
+cd /
+tar zxvf "$PACKAGE_PATH" usr
+cd /usr/lib/mozilla/plugins
+tar zxvf "$PACKAGE_PATH" libflashplayer.so


### PR DESCRIPTION
The non-free Flash package has been removed from Stretch, breaking the way we were installing the Flash plugin.

This installs Flash from the official tarball, in the way it's normally expected. It works on Stretch.