### PR TITLE
Option to generate i386-compatible images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ live-image-*
 .build/
 build.log
 
-cache/
+cache
+cache-*
 
 chroot/
 chroot.packages.*

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,16 @@ GIT_BRANCH=$(shell git branch | grep '^*' | cut -d' ' -f2)
 DATE=$(shell date +"%Y-%m-%d")
 BUILD_MSG="build: $(DATE)^$(GIT_BRANCH)"
 FINGERPRINTED_WALLPAPER=$(INCLUDES_DIR)/usr/share/w2c3/desktop-wallpaper.png
-ISO=live-image-$(ARCH).hybrid.ido
+ISO=live-image-$(ARCH).hybrid.iso
 
 amd64:
 	ARCH=amd64 THONNY_ARCH=x86_64 FLASH_ARCH=x86_64 $(MAKE) iso
 i386:
 	ARCH=i386 THONNY_ARCH=i686 FLASH_ARCH=i386 $(MAKE) iso
 
-iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
+iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint $(ISO)
+
+$(ISO):
 	cp $(FLASH_PLUGIN_PATH) $(FLASH_PLUGIN_PATH_OMIT_ARCH)
 	lb clean && lb config --architectures $(ARCH) && lb build
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-ARCH=i386
+default: amd64
+
+.PHONY: default fingerprint iso amd64 i386
+
 INCLUDES_DIR=config/includes.chroot
 FILES_CACHE_DIR=$(INCLUDES_DIR)/tmp
 DOWNLOADS_CACHE_DIR=$(FILES_CACHE_DIR)/downloads
-FLASH_PLUGIN_FILENAME=flash_player_npapi_linux.$(ARCH).tar.gz
+FLASH_PLUGIN_FILENAME=flash_player_npapi_linux.$(FLASH_ARCH).tar.gz
 FLASH_PLUGIN_FILENAME_OMIT_ARCH=flash_player_npapi_linux.tar.gz
 FLASH_PLUGIN_PATH=$(FILES_CACHE_DIR)/$(FLASH_PLUGIN_FILENAME)
 FLASH_PLUGIN_PATH_OMIT_ARCH=$(FILES_CACHE_DIR)/$(FLASH_PLUGIN_FILENAME_OMIT_ARCH)
@@ -14,21 +17,14 @@ GIT_BRANCH=$(shell git branch | grep '^*' | cut -d' ' -f2)
 DATE=$(shell date +"%Y-%m-%d")
 BUILD_MSG="build: $(DATE)^$(GIT_BRANCH)"
 FINGERPRINTED_WALLPAPER=$(INCLUDES_DIR)/usr/share/w2c3/desktop-wallpaper.png
-amd64: ARCH=amd64
-amd64: THONNY_ARCH=amd64
-i386: ARCH=i386
-i386: THONNY_ARCH=i686
+ISO=live-image-$(ARCH).hybrid.ido
 
-.PHONY: default fingerprint
+amd64:
+	ARCH=amd64 THONNY_ARCH=x86_64 FLASH_ARCH=x86_64 $(MAKE) iso
+i386:
+	ARCH=i386 THONNY_ARCH=i686 FLASH_ARCH=i386 $(MAKE) iso
 
-default: amd64
-amd64: iso
-i386: iso
-
-
-iso: live-image-$(ARCH).hybrid.iso
-
-live-image-$(ARCH).hybrid.iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
+iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
 	cp $(FLASH_PLUGIN_PATH) $(FLASH_PLUGIN_PATH_OMIT_ARCH)
 	lb clean && lb config --architectures $(ARCH) && lb build
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-ARCH=x86_64
+ARCH=i386
 INCLUDES_DIR=config/includes.chroot
 FILES_CACHE_DIR=$(INCLUDES_DIR)/tmp
 DOWNLOADS_CACHE_DIR=$(FILES_CACHE_DIR)/downloads
-FLASH_PLUGIN_FILE=flash_player_npapi_linux.x86_64.tar.gz
+FLASH_PLUGIN_FILE=flash_player_npapi_linux.$(ARCH).tar.gz
 FLASH_PLUGIN_PATH=$(FILES_CACHE_DIR)/$(FLASH_PLUGIN_FILE)
 THONNY_PACKAGE=thonny-3.0.8-$(ARCH).tar.gz
 THONNY_URL=https://bitbucket.org/plas/thonny/downloads/$(THONNY_PACKAGE)
@@ -15,9 +15,9 @@ FINGERPRINTED_WALLPAPER=$(INCLUDES_DIR)/usr/share/w2c3/desktop-wallpaper.png
 
 .PHONY: default fingerprint
 
-default: live-image-amd64.hybrid.iso
+default: live-image-$(ARCH).hybrid.iso
 
-live-image-amd64.hybrid.iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
+live-image-$(ARCH).hybrid.iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
 	lb clean && lb config && lb build
 
 fingerprint:

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ ARCH=i386
 INCLUDES_DIR=config/includes.chroot
 FILES_CACHE_DIR=$(INCLUDES_DIR)/tmp
 DOWNLOADS_CACHE_DIR=$(FILES_CACHE_DIR)/downloads
-FLASH_PLUGIN_FILE=flash_player_npapi_linux.$(ARCH).tar.gz
-FLASH_PLUGIN_PATH=$(FILES_CACHE_DIR)/$(FLASH_PLUGIN_FILE)
-THONNY_PACKAGE=thonny-3.0.8-$(ARCH).tar.gz
+FLASH_PLUGIN_FILENAME=flash_player_npapi_linux.$(ARCH).tar.gz
+FLASH_PLUGIN_FILENAME_OMIT_ARCH=flash_player_npapi_linux.tar.gz
+FLASH_PLUGIN_PATH=$(FILES_CACHE_DIR)/$(FLASH_PLUGIN_FILENAME)
+FLASH_PLUGIN_PATH_OMIT_ARCH=$(FILES_CACHE_DIR)/$(FLASH_PLUGIN_FILENAME_OMIT_ARCH)
+THONNY_PACKAGE=thonny-3.0.8-$(THONNY_ARCH).tar.gz
 THONNY_URL=https://bitbucket.org/plas/thonny/downloads/$(THONNY_PACKAGE)
 THONNY_DOWNLOAD_PATH=$(DOWNLOADS_CACHE_DIR)/$(THONNY_PACKAGE)
 ORIGINAL_WALLPAPER=$(INCLUDES_DIR)/usr/share/w2c3/desktop-wallpaper-sans-fingerprint.png
@@ -12,13 +14,23 @@ GIT_BRANCH=$(shell git branch | grep '^*' | cut -d' ' -f2)
 DATE=$(shell date +"%Y-%m-%d")
 BUILD_MSG="build: $(DATE)^$(GIT_BRANCH)"
 FINGERPRINTED_WALLPAPER=$(INCLUDES_DIR)/usr/share/w2c3/desktop-wallpaper.png
+amd64: ARCH=amd64
+amd64: THONNY_ARCH=amd64
+i386: ARCH=i386
+i386: THONNY_ARCH=i686
 
 .PHONY: default fingerprint
 
-default: live-image-$(ARCH).hybrid.iso
+default: amd64
+amd64: iso
+i386: iso
+
+
+iso: live-image-$(ARCH).hybrid.iso
 
 live-image-$(ARCH).hybrid.iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
-	lb clean && lb config && lb build
+	cp $(FLASH_PLUGIN_PATH) $(FLASH_PLUGIN_PATH_OMIT_ARCH)
+	lb clean && lb config --architectures $(ARCH) && lb build
 
 fingerprint:
 	convert $(ORIGINAL_WALLPAPER) -size 250x50 -gravity NorthWest -pointsize 20 -font courier -fill white -draw 'text 10,10 $(BUILD_MSG)' $(FINGERPRINTED_WALLPAPER)
@@ -26,7 +38,7 @@ fingerprint:
 $(FLASH_PLUGIN_PATH):
 	@echo "=========================================="
 	@echo
-	@echo "  Please download the Linux flash plugin package ($(FLASH_PLUGIN_FILE)) and leave it at:"
+	@echo "  Please download the Linux flash plugin package ($(FLASH_PLUGIN_FILENAME)) and leave it at:"
 	@echo
 	@echo "  $(FLASH_PLUGIN_PATH)"
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ i386:
 iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint $(ISO)
 
 $(ISO):
+	rm -f cache
+	mkdir -p cache-$(ARCH)
+	ln -s cache-$(ARCH) cache
 	cp $(FLASH_PLUGIN_PATH) $(FLASH_PLUGIN_PATH_OMIT_ARCH)
 	lb clean && lb config --architectures $(ARCH) && lb build
 

--- a/auto/config
+++ b/auto/config
@@ -3,7 +3,6 @@
 set -e
 
 lb config noauto \
-	--architectures i386 \
 	--archive-areas 'main contrib non-free' \
 	--debian-installer live \
 	--debian-installer-preseedfile preseed.cfg \

--- a/auto/config
+++ b/auto/config
@@ -3,6 +3,7 @@
 set -e
 
 lb config noauto \
+	--architectures i386 \
 	--archive-areas 'main contrib non-free' \
 	--debian-installer live \
 	--debian-installer-preseedfile preseed.cfg \

--- a/config/hooks/normal/1000-install-flash-plugin.hook.chroot
+++ b/config/hooks/normal/1000-install-flash-plugin.hook.chroot
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 GOODIES_DIR_PATH="/live-build/config/includes.chroot/tmp"
-PACKAGE_FILE="flash_player_npapi_linux.x86_64.tar.gz"
+PACKAGE_FILE="flash_player_npapi_linux.i386.tar.gz"
 PACKAGE_PATH="$GOODIES_DIR_PATH/$PACKAGE_FILE"
 
 cd /

--- a/config/hooks/normal/1000-install-flash-plugin.hook.chroot
+++ b/config/hooks/normal/1000-install-flash-plugin.hook.chroot
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 GOODIES_DIR_PATH="/live-build/config/includes.chroot/tmp"
-PACKAGE_FILE="flash_player_npapi_linux.i386.tar.gz"
+PACKAGE_FILE="flash_player_npapi_linux.tar.gz"
 PACKAGE_PATH="$GOODIES_DIR_PATH/$PACKAGE_FILE"
 
 cd /


### PR DESCRIPTION
We recently received a new laptop (a donation) with an architecture not compatible with amd64 builds. Fortunately, we can create compatible images with some small changes.

By default, the makefile will continue generating amd64 images. We can generate i386 images by running `make i386`.

Initially, this should be as simple as mentioning the desired architecture compatibility when calling `lb config`. Unfortunately there were a few hitches:

* If we generate an amd64 image, then a i386 image, the process will fail. Deleting the `cache` directory before a build solves this, but deleting the cache slows the build significantly. As a solution, I'm keeping architecture-specific cache directories, symlinked from `cache`. The Live Build commands do not appear to allow us to customize the cache directory, hence the symlink.
* The makefile is now recursive to work around limitations regarding variables (too complex to explain here, or to remember for that matter).
* The image should be i386-compatible, but the Thonny image is for i686, so don't expect to run this in anything less than a Pentium. (Yes, I know that would be the least of your problems if you were running this on a 486 machine with 8MB of RAM, or whatever your IoT-enabled pedal bin runs).