### PR TITLE
Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ source*.packages
 source*.zsync
 
 *.swp
+output/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ binary*.tar*
 binary*.contents
 binary*.packages
 binary*.zsync
-live-image-*
 
 .build/
 build.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get install -y make live-build git imagemagick
 
 COPY . /workspace
 
-CMD make && mv live-image-* /output/
+CMD make

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ RUN apt-get install -y make live-build git imagemagick
 
 COPY . /workspace
 
-#CMD ["make"]
-CMD make && mv live-image-*.iso /output/ && ls /output
+CMD make && mv live-image-* /output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:stretch-slim
+
+WORKDIR /workspace
+
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y make live-build git imagemagick
+
+COPY . /workspace
+
+#CMD ["make"]
+CMD make && mv live-image-*.iso /output/ && ls /output

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get install -y make live-build git imagemagick
 
 COPY . /workspace
 
-CMD make
+CMD ["make", "image"]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ FINGERPRINTED_WALLPAPER=$(INCLUDES_DIR)/usr/share/w2c3/desktop-wallpaper.png
 default: live-image-amd64.hybrid.iso
 
 live-image-amd64.hybrid.iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
-	lb clean && lb config && lb build
+	lb clean && lb config && lb build && mv live-image-* ./output/
 
 fingerprint:
 	convert $(ORIGINAL_WALLPAPER) -size 250x50 -gravity NorthWest -pointsize 20 -font courier -fill white -draw 'text 10,10 $(BUILD_MSG)' $(FINGERPRINTED_WALLPAPER)
@@ -39,4 +39,4 @@ $(THONNY_DOWNLOAD_PATH):
 
 docker-build:
 	docker build . -t w2c3-livecd
-	docker run --privileged --mount type=bind,source=$(CURDIR)/output,target=/output --mount source=w2c3-livecd-cache,target=/workspace/cache w2c3-livecd
+	docker run --privileged --mount type=bind,source=$(CURDIR)/output,target=/workspace/output --mount source=w2c3-livecd-cache,target=/workspace/cache w2c3-livecd

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ $(THONNY_DOWNLOAD_PATH):
 
 docker-build:
 	docker build . -t w2c3-livecd
-	docker run --privileged --mount type=bind,source=$(CURDIR)/output,target=/output w2c3-livecd
+	docker run --privileged --mount type=bind,source=$(CURDIR)/output,target=/output --mount source=w2c3-livecd-cache,target=/workspace/cache w2c3-livecd

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ $(THONNY_DOWNLOAD_PATH):
 
 docker-build:
 	docker build . -t w2c3-livecd
-	docker run --privileged --mount source=w2c3-livecd,target=/output w2c3-livecd
+	docker run --privileged --mount type=bind,source=$(CURDIR)/output,target=/output w2c3-livecd

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,7 @@ $(FLASH_PLUGIN_PATH):
 $(THONNY_DOWNLOAD_PATH):
 	mkdir -p $(DOWNLOADS_CACHE_DIR)
 	wget -O $(THONNY_DOWNLOAD_PATH) $(THONNY_URL)
+
+docker-build:
+	docker build . -t w2c3-livecd
+	docker run --privileged --mount source=w2c3-livecd,target=/output w2c3-livecd

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,13 @@ DATE=$(shell date +"%Y-%m-%d")
 BUILD_MSG="build: $(DATE)^$(GIT_BRANCH)"
 FINGERPRINTED_WALLPAPER=$(INCLUDES_DIR)/usr/share/w2c3/desktop-wallpaper.png
 
-.PHONY: default fingerprint
+.PHONY: default fingerprint image
 
-default: live-image-amd64.hybrid.iso
+default:
+	docker build . -t w2c3-livecd
+	docker run --privileged --mount type=bind,source=$(CURDIR)/output,target=/workspace/output --mount source=w2c3-livecd-cache,target=/workspace/cache w2c3-livecd
+
+image: live-image-amd64.hybrid.iso
 
 live-image-amd64.hybrid.iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
 	lb clean && lb config && lb build && mv live-image-* ./output/
@@ -37,6 +41,3 @@ $(THONNY_DOWNLOAD_PATH):
 	mkdir -p $(DOWNLOADS_CACHE_DIR)
 	wget -O $(THONNY_DOWNLOAD_PATH) $(THONNY_URL)
 
-docker-build:
-	docker build . -t w2c3-livecd
-	docker run --privileged --mount type=bind,source=$(CURDIR)/output,target=/workspace/output --mount source=w2c3-livecd-cache,target=/workspace/cache w2c3-livecd

--- a/README.md
+++ b/README.md
@@ -12,23 +12,73 @@ This repository contains a number of scripts to be used with Debian Live. When r
 
 ## How to run a build
 
-The [Debian Live manual](https://debian-live.alioth.debian.org/live-manual/stable/manual/html/live-manual.en.html) has a pretty good "For the impatient" section. That's a good place to start learning what all this is about. Or you can just read this section for now.
+The final product of a build is a disk image that you can transfer to a USB drive. There are two different ways of running a build:
+
+* With Docker: this is the simplest way and is preferred.
+* Natively on Debian: takes longer to set up, but it's the only option if you are on a system that doesn't support Docker.
+
+Independently of the chosen method, running a build will take a while. The first time it will download packages over the Internet and will take longer. Fortunately, many of these will be cached making this step faster in subsequent builds.
+
+### Common setup steps
+
+Start by cloning this repository if you haven't yet:
+
+```
+$ git clone https://github.com/pablobm/w2c3-livecd.git
+```
+
+We also need to manually provide the Flash plugin:
+
+1. Go to Adobe Flash's website (https://get.adobe.com/flashplayer).
+2. Download the Linux 64bit version.
+3. Put this file in the folder `config/includes.chroot/tmp` in this project.
+
+That's it for the common steps.
+
+## The Docker option
+
+For this you need:
+
+* A machine and operating system able to run Docker. Any modern computer should be able to run this, on Windows, Linux, or macOS. I'm not an expert though.
+* Docker installed: https://www.docker.com/get-started.
+* GNU Make. How to install this depends on your system. For example, on Debian it would be `sudo apt-get install make`. On macOS with Homebrew, you can do `brew install make`.
+
+Once you are set up, clone this repo from the command line, as follows:
+
+```
+$ git clone https://github.com/pablobm/w2c3-livecd.git
+```
+
+Finally, run a build:
+
+```
+$ cd w2c3-livecd
+$ make docker-build
+```
+
+The end results will appear in the `output/` folder.
+
+## The native option
+
+If your machine doesn't support Docker, or you otherwise prefer not to use it, follow this guide. You'll need a Debian Stretch (version 9) system.
+
+Even though this section is called "the native option", a virtual machine is still recommended.
+
+Note that you'll have to run everything as root: `sudo` doesn't appear to be enough.
 
 ### Setting up a virtual machine
 
-You'll need a Debian Stretch (version 9) system. A virtual machine is recommended because you'll have to run everything as root: `sudo` is not enough.
+If you choose to use a virtual machine, the setup might be different depending on the software you use. This is the process with VirtualBox:
 
-You can use [VirtualBox](https://www.virtualbox.org/) or any similar software. This is the process with VirtualBox:
+  1. Download a Debian ISO. Version should be Stretch (v9) and architecture amd64: https://www.debian.org/distrib/netinst. The "Small CD" one should do it.
 
-  1. Download a Debian ISO. Version should be Stretch (v9) and architecture amd64: https://www.debian.org/distrib/netinst. The "Small CD" one should make it.
+  2. Install VirtualBox, downloading the appropriate version for your host OS: https://www.virtualbox.org/wiki/Downloads.
 
-  2. Install VirtualBox, downloading the appropriate version for your host OS: https://www.virtualbox.org/wiki/Downloads
+  3. Create VM to run Linux Debian 64 bit. I recommend a 25GB hard drive. I'm also assigning it 1024 MB memory, but can't be sure what's better there.
 
-  3. Create VM to run Linux Debian 64 bit. I recommend a 20GB hard drive. I'm also assigning it 1024 MB memory, but can't be sure what's better there
+  4. Install and boot.
 
-  4. Install and boot
-
-  5. You'll need the Guest Additions package, which in turns requires some development packages. On the menu bar, go to "Devices > Install Guest Additions CD image", and install as follows:
+  5. You'll need the Guest Additions package, which in turns requires some development packages. On the menu bar, go to "Devices > Install Guest Additions CD image", and install as follows (as root):
 
 ```
 # apt-get install make gcc linux-headers-amd64
@@ -42,33 +92,19 @@ Finally restart the VM and you'll be set.
 
 As mentioned above, do everything as root. Using `sudo` is not enough.
 
-First install live-build and git:
+First install the required packages:
 
 ```
-# apt-get install live-build git imagemagick
+# apt-get install live-build imagemagick
 ```
-
-Next, clone this repository:
-
-```
-# git clone https://github.com/pablobm/w2c3-livecd.git
-```
-
-Since the Flash plugin is not available in the Debian repository, we'll have to provide it manually:
-
-1. Go to Adobe Flash's website (https://get.adobe.com/flashplayer).
-2. Download the Linux 64bit version.
-3. Put this file in the folder `config/includes.chroot/tmp` in this project.
-
 
 Finally, run a build:
 
 ```
-# cd w2c3-livecd
 # make
 ```
 
-This will take a while! The first time it will download packages over the Internet and will take longer. Fortunately, these will be cached (under `cache/`) making this step faster in subsequent builds.
+The end results will appear in the `output/` folder.
 
 ## Implementation details
 
@@ -76,7 +112,9 @@ There are some "special" customisations on these scripts, but mostly it's all pr
 
 ### The standard bits
 
-Check out the [Debian Live manual](https://debian-live.alioth.debian.org/live-manual/stable/manual/html/live-manual.en.html) to get familiar with the basics of creating a build. Some quick notes:
+Check out the [Debian Live manual](https://live-team.pages.debian.net/live-manual/html/live-manual/index.en.html) to get familiar with the basics of creating a build. There's a pretty good "For the impatient" section to get started.
+
+Some quick notes:
 
   * See `config/package-lists` for lists of packages that are included in the build
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For this you need:
 If everything is in place, you can now run a build:
 
 ```
-$ make docker-build
+$ make
 ```
 
 The end results will appear in the `output/` folder.
@@ -94,7 +94,7 @@ This should be enough:
 As mentioned above, do everything as root. Using `sudo` is not enough. Use Make to run the build:
 
 ```
-# make
+# make image
 ```
 
 The end results will appear in the `output/` folder.

--- a/README.md
+++ b/README.md
@@ -43,16 +43,9 @@ For this you need:
 * Docker installed: https://www.docker.com/get-started.
 * GNU Make. How to install this depends on your system. For example, on Debian it would be `sudo apt-get install make`. On macOS with Homebrew, you can do `brew install make`.
 
-Once you are set up, clone this repo from the command line, as follows:
+If everything is in place, you can now run a build:
 
 ```
-$ git clone https://github.com/pablobm/w2c3-livecd.git
-```
-
-Finally, run a build:
-
-```
-$ cd w2c3-livecd
 $ make docker-build
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If your machine doesn't support Docker, or you otherwise prefer not to use it, f
 
 Even though this section is called "the native option", a virtual machine is still recommended.
 
-Note that you'll have to run everything as root: `sudo` doesn't appear to be enough.
+Note that the given lines assume that you are root, as it's required in the last step anyway.
 
 ### Setting up a virtual machine
 
@@ -91,7 +91,7 @@ This should be enough:
 
 ### Running the build
 
-As mentioned above, do everything as root. Using `sudo` is not enough. Use Make to run the build:
+Finally you run Make. This has to be done as root (or so it appeared last time I tried to just sudo it):
 
 ```
 # make image

--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ Finally restart the VM and you'll be set.
 
 ### Installing required packages
 
-As mentioned above, do everything as root. Using `sudo` is not enough.
-
-First install the required packages:
+This should be enough:
 
 ```
 # apt-get install live-build imagemagick
 ```
 
-Finally, run a build:
+### Running the build
+
+As mentioned above, do everything as root. Using `sudo` is not enough. Use Make to run the build:
 
 ```
 # make

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We also need to manually provide the Flash plugin:
 2. Download the Linux 64bit version.
 3. Put this file in the folder `config/includes.chroot/tmp` in this project.
 
-That's it for the common steps.
+Next, follow the instructions on the section appropriate for your preferred build method.
 
 ## The Docker option
 


### PR DESCRIPTION
Use Docker to run builds, which is so much more convenient.

This PR changes the interface to the main build task: running `make` now performs the Docker-based build, while the "classic" native build (which is run behind the scenes during the Docker build) is run with `make image`.