### PR TITLE
Adding an Install Thonny icon to the desktop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ FILES_CACHE_DIR=$(INCLUDES_DIR)/tmp
 DOWNLOADS_CACHE_DIR=$(FILES_CACHE_DIR)/downloads
 FLASH_PLUGIN_FILE=flash_player_npapi_linux.x86_64.tar.gz
 FLASH_PLUGIN_PATH=$(FILES_CACHE_DIR)/$(FLASH_PLUGIN_FILE)
-THONNY_PACKAGE=thonny-3.0.8-$(ARCH).tar.gz
-THONNY_URL=https://bitbucket.org/plas/thonny/downloads/$(THONNY_PACKAGE)
-THONNY_DOWNLOAD_PATH=$(DOWNLOADS_CACHE_DIR)/$(THONNY_PACKAGE)
 ORIGINAL_WALLPAPER=$(INCLUDES_DIR)/usr/share/w2c3/desktop-wallpaper-sans-fingerprint.png
 GIT_BRANCH=$(shell git branch | grep '^*' | cut -d' ' -f2)
 DATE=$(shell date +"%Y-%m-%d")
@@ -21,7 +18,7 @@ default:
 
 image: live-image-amd64.hybrid.iso
 
-live-image-amd64.hybrid.iso: $(FLASH_PLUGIN_PATH) $(THONNY_DOWNLOAD_PATH) fingerprint
+live-image-amd64.hybrid.iso: $(FLASH_PLUGIN_PATH) fingerprint
 	lb clean && lb config && lb build && mv live-image-* ./output/
 
 fingerprint:
@@ -36,8 +33,3 @@ $(FLASH_PLUGIN_PATH):
 	@echo
 	@echo "=========================================="
 	@exit 1
-
-$(THONNY_DOWNLOAD_PATH):
-	mkdir -p $(DOWNLOADS_CACHE_DIR)
-	wget -O $(THONNY_DOWNLOAD_PATH) $(THONNY_URL)
-

--- a/config/hooks/normal/1010-copy-downloads.hook.chroot
+++ b/config/hooks/normal/1010-copy-downloads.hook.chroot
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-set -e
-
-DOWNLOADS_CACHE_DIR="/live-build/config/includes.chroot/tmp/downloads"
-DEST_DIR="/usr/share/w2c3/software"
-
-mkdir -p "$DEST_DIR"
-cp -pr "$DOWNLOADS_CACHE_DIR"/* "$DEST_DIR/"

--- a/config/includes.chroot/etc/skel/.thonny/configuration.ini
+++ b/config/includes.chroot/etc/skel/.thonny/configuration.ini
@@ -1,2 +1,0 @@
-[view]
-show_line_numbers = True

--- a/config/includes.chroot/etc/skel/Desktop/install-thonny.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/install-thonny.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Name=Install Thonny
+Comment=Install the Thonny Python IDE for beginners
+Exec=bash -c 'bash <(wget -O - https://thonny.org/installer-for-linux)'
+Icon=utilities-terminal
+Terminal=true 
+Type=Application

--- a/config/includes.chroot/etc/skel/Desktop/software.desktop
+++ b/config/includes.chroot/etc/skel/Desktop/software.desktop
@@ -1,5 +1,0 @@
-[Desktop Entry]
-Type=Link
-Name=Software
-Icon=folder
-URL=/usr/share/w2c3/software


### PR DESCRIPTION
Rather than including a fixed version of the Thonny binary in the image instead this PR adds an "Install Thonny" icon to the desktop which runs the standard Thonny install when clicked.

If we need to upgrade Thonny this can be run again.